### PR TITLE
Fix mobile navbar brand font size overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -1443,6 +1443,10 @@ section {
         font-size: 2rem;
     }
 
+    .nav-brand h2 {
+        font-size: 1.5rem;
+    }
+
     section {
         padding: 60px 0;
     }


### PR DESCRIPTION
Fixed an issue where the navbar brand text overflowed on mobile screens. Reduced font size in the 768px media query to maintain proper layout and readability.