### PR TITLE
Standardize CTA button labels for UI consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
         <section class="cta-section" aria-labelledby="cta-title">
             <div class="container">
                 <h2 id="cta-title">Start Your Free Career Assessment Today</h2>
-                <button class="btn btn--primary btn--lg" onclick="handleGetStartedClick()" aria-label="Start your free career assessment now">Get Started Now</button>
+                <button class="btn btn--primary btn--lg" onclick="handleGetStartedClick()" aria-label="Start your free career assessment now">Get Started</button>
             </div>
         </section>
     </div>


### PR DESCRIPTION
## 📌 Description
Standardized all call-to-action (CTA) button labels to "Get Started" across multiple pages for improved UI consistency and clarity. This change ensures uniform terminology and avoids confusion caused by mixed labels such as "Get Started" and "Get Started Now".

Fixes: #21

---

## 🔧 Type of Change

- [x] 🎨 UI / Styling change

---

## 🧪 How Has This Been Tested?

- [x] Manual testing — verified visually in browser that CTA labels render correctly with no layout or functional issues.

---

## 📸 Screenshots (if applicable)

_Not required for this change, as UI difference is purely textual._

---

## ✅ Checklist

- [x] My changes follow the project's coding style
- [x] I have tested my changes locally
- [x] This PR does not introduce breaking changes
- [x] Issue #21 referenced

---

## 📝 Additional Notes
No functional behavior has changed. This update purely improves UX consistency.
