### PR TITLE
Make Get Started open signup and capture preferred career

### DIFF
--- a/assets/scripts/app.js
+++ b/assets/scripts/app.js
@@ -171,6 +171,9 @@ function handleGetStartedClick() {
     showPage("dashboard");
   } else {
     showPage("auth");
+    showRegisterForm();
+    const firstRegisterField = document.getElementById("register-name");
+    if (firstRegisterField) firstRegisterField.focus();
   }
 }
 
@@ -269,8 +272,10 @@ function login() {
 function register() {
   const name = document.getElementById("register-name").value;
   const email = document.getElementById("register-email").value;
+  const preferredCareer = document.getElementById("register-career")?.value;
   const password = document.getElementById("register-password").value;
-  if (!name || !email || !password) return alert("Please fill all fields");
+  if (!name || !email || !password || !preferredCareer)
+    return alert("Please fill all fields and select a preferred career path");
 
   const users = JSON.parse(localStorage.getItem("users") || "[]");
   if (users.some((u) => u.email === email))
@@ -280,6 +285,7 @@ function register() {
     id: Date.now(),
     name,
     email,
+    preferredCareer,
     password,
     profile: null,
     enrolledCourses: [],

--- a/index.html
+++ b/index.html
@@ -205,6 +205,21 @@
                         <div id="register-email-help" class="sr-only">Enter a valid email address for your account</div>
                     </div>
                     <div class="form-group">
+                        <label class="form-label" for="register-career">Preferred Career Path</label>
+                        <select class="form-control" id="register-career" required aria-describedby="register-career-help">
+                            <option value="">Select your preferred path</option>
+                            <option value="software-development">Software Development</option>
+                            <option value="data-science">Data Science / AI</option>
+                            <option value="design">UI/UX Design</option>
+                            <option value="product-management">Product Management</option>
+                            <option value="cybersecurity">Cybersecurity</option>
+                            <option value="cloud-devops">Cloud & DevOps</option>
+                            <option value="business-analytics">Business Analytics</option>
+                            <option value="other">Other / Exploring</option>
+                        </select>
+                        <div id="register-career-help" class="sr-only">Choose the career path you want to pursue so we can personalize recommendations</div>
+                    </div>
+                    <div class="form-group">
                         <label class="form-label" for="register-password">Password</label>
                         <input type="password" class="form-control" id="register-password" placeholder="Create a password" required aria-describedby="register-password-help">
                         <div id="register-password-help" class="sr-only">Create a strong password with at least 8 characters</div>


### PR DESCRIPTION
## 📌 Description
- Make all Get Started buttons open the signup view directly and focus the first field for faster onboarding.
- Add a required “Preferred Career Path” selector to registration and store it on the user record so personalization is possible.
- Keeps existing login flow and dashboard routing unchanged.

Fixes: #142

---

## 🔧 Type of Change
- [x] ✨ New feature

---

## 🧪 How Has This Been Tested?
- [x] Manual testing
  - Open index.html, click any Get Started → lands on Register form with focus on name field.
  - Attempt registration without selecting a career → blocked with alert.
  - Register with name/email/password/preferred career → succeeds, navigates to profile setup, and user data is stored (including preferred career) in localStorage.

---

## 📸 Screenshots (if applicable)
N/A (no visual change beyond new dropdown)

---

## ✅ Checklist
- [x] My code follows the project’s coding style
- [x] I have tested my changes
- [x] This PR does not introduce breaking changes

---

## 📝 Additional Notes
None.